### PR TITLE
[ILA][xilinx] Extend flow for ILA probes

### DIFF
--- a/hw/xilinx/Makefile
+++ b/hw/xilinx/Makefile
@@ -45,13 +45,19 @@ endif
 SYNTH_STRATEGY ?= Flow_RuntimeOptimized
 IMPL_STRATEGY ?= Flow_RuntimeOptimized
 
+# Implementation artifacts
+XILINX_BITSTREAM   ?= ${XILINX_PROJECT_BUILD_DIR}/${XILINX_PROJECT_NAME}.runs/impl_1/${XILINX_PROJECT_NAME}.bit
+XILINX_PROBE_LTX ?= ${XILINX_PROJECT_BUILD_DIR}/${XILINX_PROJECT_NAME}.runs/impl_1/${XILINX_PROJECT_NAME}.ltx
+
+# Whether to use ILA probes (0|1)
+XILINX_ILA ?= 1
+
 # Full environment variables list for Vivado
-# XILINX_PROJECT_LTX=${XILINX_PROJECT_LTX}
-XILINX_BITSTREAM ?= ${XILINX_PROJECT_BUILD_DIR}/${XILINX_PROJECT_NAME}.runs/impl_1/${XILINX_PROJECT_NAME}.bit
 XILINX_VIVADO_ENV ?=              					\
 	AXI_DATA_WIDTH=${AXI_DATA_WIDTH}				\
 	AXI_ADDR_WIDTH=${AXI_ADDR_WIDTH}				\
 	AXI_ID_WIDTH=${AXI_ID_WIDTH}					\
+	XILINX_ILA=${XILINX_ILA}						\
 	SYNTH_STRATEGY=${SYNTH_STRATEGY}				\
 	IMPL_STRATEGY=${IMPL_STRATEGY}					\
     XILINX_PART_NUMBER=${XILINX_PART_NUMBER}   		\
@@ -62,6 +68,7 @@ XILINX_VIVADO_ENV ?=              					\
     XILINX_HW_SERVER_PORT=${XILINX_HW_SERVER_PORT}  \
     XILINX_FPGA_DEVICE=${XILINX_FPGA_DEVICE}		\
     XILINX_BITSTREAM=${XILINX_BITSTREAM}   			\
+	XILINX_PROBE_LTX=${XILINX_PROBE_LTX}		\
 	XILINX_IP_LIST_XCI="${XILINX_IP_LIST_XCI}" 		\
 	XILINX_ROOT=${XILINX_ROOT}						\
     QUESTA_PATH=${QUESTA_PATH}   					\
@@ -115,11 +122,16 @@ ips: ${XILINX_IP_NAMES}
 start_hw_server:
 	hw_server -d -L- -stcp::${XILINX_HW_SERVER_PORT}
 
-# Open Vivado hardware manager
+# Open Vivado hardware manager in tcl mode
 open_hw_manager:
 	${XILINX_VIVADO_ENV} ${XILINX_VIVADO_CMD} -mode tcl \
 		-source ${XILINX_SYNTH_TCL_ROOT}/$@.tcl
-# -source ${XILINX_SYNTH_TCL_ROOT}/set_ila_trigger.tcl
+
+# Open ILA dashboard GUI
+open_ila:
+		${XILINX_VIVADO_ENV} ${XILINX_VIVADO_CMD} -mode gui \
+		-source ${XILINX_SYNTH_TCL_ROOT}/open_hw_manager.tcl \
+		-source ${XILINX_SYNTH_TCL_ROOT}/set_ila_trigger.tcl
 
 program_bitstream:
 	${XILINX_VIVADO} \

--- a/hw/xilinx/synth/tcl/add_ila.tcl
+++ b/hw/xilinx/synth/tcl/add_ila.tcl
@@ -1,0 +1,60 @@
+# Author: Vincenzo Maisto <vincenzo.maisto2@unina.it>
+# Author: Cyril Koenig <cykoenig@iis.ee.ethz.ch>
+# Description: Create an ILA core and attach all nets in the design marked as MARK_DEBUG.
+
+# ILA clock from SoC design
+set clk_net_name sys_master_u/soc_clk_o
+
+# Get market nets
+set debug_nets [lsort -dictionary [get_nets -hier -filter {MARK_DEBUG == 1}]]
+
+# Return if there is any marked net
+if { ![llength $debug_nets] } {
+    puts "\[ILA\] No nets marked for debug"
+    return
+}
+
+# Create and configure debug core
+puts "\[ILA\] Creating debug core..."
+create_debug_core ila_u ila
+set_property -dict [list \
+        ALL_PROBE_SAME_MU       {true}  \
+        ALL_PROBE_SAME_MU_CNT   {4}     \
+        C_ADV_TRIGGER           {true}  \
+        C_DATA_DEPTH            {16384} \
+        C_EN_STRG_QUAL          {true}  \
+        C_INPUT_PIPE_STAGES     {0}     \
+        C_TRIGIN_EN             {false} \
+        C_TRIGOUT_EN            {false} \
+    ] [get_debug_cores ila_u]
+
+# Connect SoC clock
+set_property port_width 1 [get_debug_ports ila_u/clk]
+connect_debug_port ila_u/clk [get_nets $clk_net_name]
+
+# Loop through debug nets (add extra list element to ensure last net is processed)
+set net_name_last ""
+set i 0
+foreach net [concat $debug_nets {""}] {
+    # Remove trailing array index
+    regsub {\[[0-9]*\]$} $net {} net_name
+    # Create probe after all signals with the same name have been collected
+    if { $net_name_last != $net_name } {
+        if { $net_name_last != "" } {
+            puts "\[ILA\] Creating probe $i of width [llength $sig_list] for `$net_name_last`."
+            # probe0 already exists, and does not need to be created
+            if { $i != 0 } { create_debug_port ila_u probe }
+            set_property port_width [llength $sig_list] [get_debug_ports ila_u/probe$i]
+            set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports ila_u/probe$i]
+            connect_debug_port ila_u/probe$i [get_nets $sig_list]
+            incr i
+        }
+        set sig_list ""
+    }
+    lappend sig_list $net
+    set net_name_last $net_name
+}
+
+# Save constraints, then implement the debug core
+save_constraints -force
+implement_debug_core

--- a/hw/xilinx/synth/tcl/add_ilas.tcl
+++ b/hw/xilinx/synth/tcl/add_ilas.tcl
@@ -1,1 +1,0 @@
-# TODO: import from Cyril? check license

--- a/hw/xilinx/synth/tcl/mark_debug_nets.tcl
+++ b/hw/xilinx/synth/tcl/mark_debug_nets.tcl
@@ -1,0 +1,5 @@
+# Author: Vincenzo Maisto <vincenzo.maisto2@unina.it>
+# Description: Mark nets in the post-syntesis netlist for debug
+
+# System master AXI interface
+set_property MARK_DEBUG 1 [get_nets sys_master_to_xbar_*]

--- a/hw/xilinx/synth/tcl/open_hw_manager.tcl
+++ b/hw/xilinx/synth/tcl/open_hw_manager.tcl
@@ -1,8 +1,5 @@
 # Author: Vincenzo Maisto <vincenzo.maisto2@unina.it>
-# Description: Open Vivado Hardware Manager
-
-# First check if the probe file exists
-# exec ls $::env(XILINX_PROJECT_LTX) 
+# Description: Open Vivado Hardware Manager and set probe file
 
 # Connect to hw server
 open_hw_manager
@@ -20,17 +17,3 @@ set_property PARAM.FREQUENCY 15000000 [get_hw_targets $target]
 set hw_device [get_hw_devices $::env(XILINX_HW_DEVICE)]
 # Select hw device
 current_hw_device $hw_device
-
-# # TODO: when adding ILAs
-# # puts "Using probe file $::env(XILINX_PROJECT_LTX)"
-# # set_property PROBES.FILE      $::env(XILINX_PROJECT_LTX) $hw_device
-# # set_property FULL_PROBES.FILE $::env(XILINX_PROJECT_LTX) $hw_device
-# # current_hw_device                                        $hw_device
-
-# # Debug
-# puts "Query the design"
-# report_property -all [get_hw_targets $target]
-
-# # Search for hw probes
-refresh_hw_device [lindex $hw_device 0]
-


### PR DESCRIPTION
[ILA][xilinx] Extend flow for ILA probes

* Control ILA instantiation with envvar XILINX_ILA=(0|1)

* Add TCL script automatic ILA instantiation (add_ila)

* Fix TCL script for marking nets in the post-synthesis netlist (mark_debug_nets)

* Add open_ila Makefile target

* Add handling of probe file (.ltx)

* Minor refactoring on TCL build script for reports

NOTE: ILA IP needs to build between synthesis and implementation, hence adding a couple of minutes to the overall bitstream build