### PR TITLE
[fix/plic_line_fix] Fixing wrong interrupt bit line in uninasoc.sv

### DIFF
--- a/hw/xilinx/rtl/peripheral_bus.sv
+++ b/hw/xilinx/rtl/peripheral_bus.sv
@@ -97,7 +97,11 @@ module peripheral_bus #(
     // EMBEDDED ONLY
     logic gpio_in_int;
 
-    assign int_o = {uart_int, tim1_int, tim0_int, gpio_in_int};
+    // Assign interrupt pins
+    assign int_o[PBUS_GPIOIN_INTERRUPT] = gpio_in_int;
+    assign int_o[PBUS_TIM0_INTERRUPT]   = tim0_int;
+    assign int_o[PBUS_TIM1_INTERRUPT]   = tim1_int;
+    assign int_o[PBUS_UART_INTERRUPT]   = uart_int;
 
     /////////////////////
     // AXI-lite Master //

--- a/hw/xilinx/rtl/rvm_socket.sv
+++ b/hw/xilinx/rtl/rvm_socket.sv
@@ -242,9 +242,9 @@ module rvm_socket # (
 
                 // Interrupts
                 // Ublaze can only take one external interrupt, which we tie to EXT interrupt (from the PLIC)
-                .Interrupt          ( irq_i[EXT_INT_PIN]    ), // input wire Interrupt
-                .Interrupt_Address  ('0                     ), // input wire [0 : 31] Interrupt_Address
-                .Interrupt_Ack      (                       ), // output wire [0 : 1] Interrupt_Ack
+                .Interrupt          ( irq_i[CORE_EXT_INTERRUPT] ), // input wire Interrupt
+                .Interrupt_Address  ('0                         ), // input wire [0 : 31] Interrupt_Address
+                .Interrupt_Ack      (                           ), // output wire [0 : 1] Interrupt_Ack
 
                 // Debug port to MDMV
                 .Dbg_Clk            ( Dbg_Clk     ), // input wire Dbg_Clk

--- a/hw/xilinx/rtl/rvm_socket.sv
+++ b/hw/xilinx/rtl/rvm_socket.sv
@@ -47,10 +47,6 @@ module rvm_socket # (
     localparam logic [31:0] dm_HaltAddress = 64'h800;
     localparam logic [31:0] dm_ExceptionAddress = dm_HaltAddress + 16;
 
-    localparam SW_INT_PIN = 3;
-    localparam TIM_INT_PIN = 7;
-    localparam EXT_INT_PIN = 11;
-
     //////////////////////////////////////
     //    ___ _                _        //
     //   / __(_)__ _ _ _  __ _| |___    //

--- a/hw/xilinx/rtl/uninasoc.sv
+++ b/hw/xilinx/rtl/uninasoc.sv
@@ -548,7 +548,7 @@ module uninasoc (
     logic plic_int_irq_o;
 
     // Line 11 corresponds to EXT interrupt in RISC-V specification
-    assign rvm_socket_interrupt_line = {21'h0, plic_int_irq_o, 10'h0};
+    assign rvm_socket_interrupt_line = {'0, plic_int_irq_o, 11'h0};
 
     // Currently, this is the interrupt line mapping (from PLIC perspective/registers)
     // 0 - RESERVED

--- a/hw/xilinx/rtl/uninasoc.sv
+++ b/hw/xilinx/rtl/uninasoc.sv
@@ -554,7 +554,7 @@ module uninasoc (
 
         // Mapping PLIC input interrupts (only from pbus at the moment)
         // Mapping is static (refer to uninasoc_pkg.sv)
-        plic_int_line[PLIC_RESERVED_INTERRUPT]  = 1'b0; 
+        plic_int_line[PLIC_RESERVED_INTERRUPT]  = 1'b0;
         plic_int_line[PLIC_GPIOIN_INTERRUPT]    = pbus_int_line[PBUS_GPIOIN_INTERRUPT];
         plic_int_line[PLIC_TIM0_INTERRUPT]      = pbus_int_line[PBUS_TIM0_INTERRUPT];
         plic_int_line[PLIC_TIM1_INTERRUPT]      = pbus_int_line[PBUS_TIM1_INTERRUPT];
@@ -565,7 +565,7 @@ module uninasoc (
 
     end : system_interrupts
 
- 
+
     custom_rv_plic custom_rv_plic_u (
         .clk_i          ( soc_clk                       ), // input wire s_axi_aclk
         .rst_ni         ( sys_resetn                    ), // input wire s_axi_aresetn

--- a/hw/xilinx/rtl/uninasoc.sv
+++ b/hw/xilinx/rtl/uninasoc.sv
@@ -548,21 +548,20 @@ module uninasoc (
 
     always_comb begin : system_interrupts
 
-        // Mapping PLIC input interrupts (only from pbus at the moment)
-        plic_int_line = {
-            '0,                 // others - reserved
-            pbus_int_line[3],   // 4 - UART Interrupt    (From PBUS) (HPC implementation does not support this yet)
-            pbus_int_line[2],   // 3 - Timer 1 Interrupt (From PBUS)
-            pbus_int_line[1],   // 2 - Timer 0 Interrupt (From PBUS)
-            pbus_int_line[0],   // 1 - GPIO_IN Interrupt (From PBUS) (Embedded Only)
-            1'b0};              // 0 - RESERVED
-
-        // Mppinag PLIC to Socket interrupt lines
-
         // Default non-assigned lines
+        plic_int_line = '0;
         rvm_socket_interrupt_line = '0;
+
+        // Mapping PLIC input interrupts (only from pbus at the moment)
+        // Mapping is static (refer to uninasoc_pkg.sv)
+        plic_int_line[PLIC_RESERVED_INTERRUPT]  = 1'b0; 
+        plic_int_line[PLIC_GPIOIN_INTERRUPT]    = pbus_int_line[PBUS_GPIOIN_INTERRUPT];
+        plic_int_line[PLIC_TIM0_INTERRUPT]      = pbus_int_line[PBUS_TIM0_INTERRUPT];
+        plic_int_line[PLIC_TIM1_INTERRUPT]      = pbus_int_line[PBUS_TIM1_INTERRUPT];
+        plic_int_line[PLIC_UART_INTERRUPT]      = pbus_int_line[PBUS_UART_INTERRUPT];
+
         // Map system-interrupts pins to socket interrupts
-        rvm_socket_interrupt_line[EXT_INT_PIN] = plic_int_irq_o;
+        rvm_socket_interrupt_line[CORE_EXT_INTERRUPT] = plic_int_irq_o;
 
     end : system_interrupts
 

--- a/hw/xilinx/rtl/uninasoc_pkg.sv
+++ b/hw/xilinx/rtl/uninasoc_pkg.sv
@@ -11,10 +11,6 @@ package uninasoc_pkg;
     localparam int unsigned NUM_GPIO_IN  = 16;
     localparam int unsigned NUM_GPIO_OUT = 16;
 
-    localparam int unsigned SW_INT_PIN = 3;
-    localparam int unsigned TIM_INT_PIN = 7;
-    localparam int unsigned EXT_INT_PIN = 11;
-
     ///////////////////////
     // AXI main crossbar //
     ///////////////////////
@@ -45,5 +41,31 @@ package uninasoc_pkg;
     // Select core from macro
     localparam core_selector_t CORE_SELECTOR = `CORE_SELECTOR;
 
+    ///////////////////////
+    // System Interrupts //
+    ///////////////////////
+
+    // Masters and Buses (Slves) can generate interrupts, which are forwarded to the PLIC (Platform interrupts).
+    // The PLIC forwards interrupts to the Masters (e.g. the Socket)
+
+    // RISC-V cores standard interrupts 
+    localparam int unsigned CORE_SW_INTERRUPT = 3;      // Inter Processor Interrupts
+    localparam int unsigned CORE_TIM_INTERRUPT = 7;     // Real-time Clock Timer
+    localparam int unsigned CORE_EXT_INTERRUPT = 11;    // PLIC-to-hart interrupts
+
+    // Peripheral Bus interrupts
+    localparam int unsigned PBUS_GPIOIN_INTERRUPT = 0;      // GPIO In [embedded only]
+    localparam int unsigned PBUS_TIM0_INTERRUPT = 1;        // Timer 0 
+    localparam int unsigned PBUS_TIM1_INTERRUPT = 2;        // Timer 1 
+    localparam int unsigned PBUS_UART_INTERRUPT = 3;        // UART
+
+    // PLIC Interrupts mapping
+    // We support 32 possible sources of platform interrupts, which are statically mapped
+    // regardless of the configuration. 
+    localparam int unsigned PLIC_RESERVED_INTERRUPT = 0;    // PLIC line 0 is reserved
+    localparam int unsigned PLIC_GPIOIN_INTERRUPT = 1;      // GPIO In (From PBUS)[embedded only]
+    localparam int unsigned PLIC_TIM0_INTERRUPT = 2;        // Timer 0 (From PBUS)
+    localparam int unsigned PLIC_TIM1_INTERRUPT = 3;        // Timer 1 (From PBUS)
+    localparam int unsigned PLIC_UART_INTERRUPT = 4;        // UART    (From PBUS)
 
 endpackage : uninasoc_pkg

--- a/hw/xilinx/rtl/uninasoc_pkg.sv
+++ b/hw/xilinx/rtl/uninasoc_pkg.sv
@@ -48,20 +48,20 @@ package uninasoc_pkg;
     // Masters and Buses (Slves) can generate interrupts, which are forwarded to the PLIC (Platform interrupts).
     // The PLIC forwards interrupts to the Masters (e.g. the Socket)
 
-    // RISC-V cores standard interrupts 
+    // RISC-V cores standard interrupts
     localparam int unsigned CORE_SW_INTERRUPT = 3;      // Inter Processor Interrupts
     localparam int unsigned CORE_TIM_INTERRUPT = 7;     // Real-time Clock Timer
     localparam int unsigned CORE_EXT_INTERRUPT = 11;    // PLIC-to-hart interrupts
 
     // Peripheral Bus interrupts
     localparam int unsigned PBUS_GPIOIN_INTERRUPT = 0;      // GPIO In [embedded only]
-    localparam int unsigned PBUS_TIM0_INTERRUPT = 1;        // Timer 0 
-    localparam int unsigned PBUS_TIM1_INTERRUPT = 2;        // Timer 1 
+    localparam int unsigned PBUS_TIM0_INTERRUPT = 1;        // Timer 0
+    localparam int unsigned PBUS_TIM1_INTERRUPT = 2;        // Timer 1
     localparam int unsigned PBUS_UART_INTERRUPT = 3;        // UART
 
     // PLIC Interrupts mapping
     // We support 32 possible sources of platform interrupts, which are statically mapped
-    // regardless of the configuration. 
+    // regardless of the configuration.
     localparam int unsigned PLIC_RESERVED_INTERRUPT = 0;    // PLIC line 0 is reserved
     localparam int unsigned PLIC_GPIOIN_INTERRUPT = 1;      // GPIO In (From PBUS)[embedded only]
     localparam int unsigned PLIC_TIM0_INTERRUPT = 2;        // Timer 0 (From PBUS)

--- a/hw/xilinx/rtl/uninasoc_pkg.sv
+++ b/hw/xilinx/rtl/uninasoc_pkg.sv
@@ -11,6 +11,10 @@ package uninasoc_pkg;
     localparam int unsigned NUM_GPIO_IN  = 16;
     localparam int unsigned NUM_GPIO_OUT = 16;
 
+    localparam int unsigned SW_INT_PIN = 3;
+    localparam int unsigned TIM_INT_PIN = 7;
+    localparam int unsigned EXT_INT_PIN = 11;
+
     ///////////////////////
     // AXI main crossbar //
     ///////////////////////
@@ -27,7 +31,6 @@ package uninasoc_pkg;
     // Always assume 1 master
     // Peripheral bus slaves
     localparam int unsigned PBUS_NUM_MI = `PBUS_NUM_MI;
-
 
     //////////////////////////
     // Supported Processors //


### PR DESCRIPTION
- [fix] EXT interrupt line was wrongly mapped to pin 10 instead of 11
- [refactor] Export interrupt mappings in uninasoc_pkg.sv