### PR TITLE
[fix/stale_units] Fix and enhance unit flow

### DIFF
--- a/hw/units/Makefile
+++ b/hw/units/Makefile
@@ -22,6 +22,10 @@ custom_%/rtl:
 		false; \
 	fi
 
+# Selectively remove a single RTL dir
+clean_custom_%:
+	rm -rf ${HW_UNITS_ROOT}/$*/rtl
+
 # Remove all RTL dirs
 clean:
 	rm -rf ${HW_UNITS_ROOT}/*/rtl

--- a/hw/units/Makefile
+++ b/hw/units/Makefile
@@ -14,7 +14,13 @@ units: $(addsuffix /rtl, ${IP_RTL_LIST})
 
 # Fetch sources for all IPs without local rtl
 custom_%/rtl:
-	cd ${HW_UNITS_ROOT}/custom_$*; source fetch_sources.sh
+	cd ${HW_UNITS_ROOT}/custom_$*; source fetch_sources.sh \
+# 	Check if sources are preset, error otherwise and clean stale dir
+	if [ -z "$(shell ls -A $${HW_UNITS_ROOT}/$$@)" ]; then \
+		echo "[UNITS] Failed to fetch sources for $@"  >&2; \
+		rm -rf $@; \
+		false; \
+	fi
 
 # Remove all RTL dirs
 clean:


### PR DESCRIPTION
* [units] If the fetch_sources.sh scritps create an empty rtl/ directory, even if returning an error code, the Makefile could previously not detect this
. Consequently, since the rtl/ dir was in place, make would think that the custom_%/rtl target was done and required no rebuild
* [units] Add a single-unit tageted clean rule