### PR TITLE
[feature/pcie_rescan] Add PCIe rescan for bitstream programming in HPC

### DIFF
--- a/hw/xilinx/make/utils.mk
+++ b/hw/xilinx/make/utils.mk
@@ -46,10 +46,22 @@ vio_%:
 		-source ${XILINX_SCRIPTS_UTILS_ROOT}/open_hw_manager.tcl \
 		-source ${XILINX_SCRIPTS_UTILS_ROOT}/vio_reset.tcl -tclargs $@
 
-program_bitstream:
+# Program the bitstream based on the SoC profile
+program_bitstream: program_bitstream_${SOC_CONFIG}
+
+# Program bitstream for embedded profile
+program_bitstream_embedded:
 	${XILINX_VIVADO} \
 		-source ${XILINX_SCRIPTS_UTILS_ROOT}/open_hw_manager.tcl \
 		-source ${XILINX_SCRIPTS_UTILS_ROOT}/$@.tcl
 
+# Program bitstream for HPC profile
+PCIE_DEV ?= 01:00.0 # TODO: remove this and find the dev automatically in the script
+program_bitstream_hpc:
+	${XILINX_VIVADO} \
+		-source ${XILINX_SCRIPTS_UTILS_ROOT}/open_hw_manager.tcl \
+		-source ${XILINX_SCRIPTS_UTILS_ROOT}/$@.tcl
+	sudo ${XILINX_SCRIPTS_UTILS_ROOT}/pcie_hot_reset.sh ${PCIE_DEV}
+
 # PHONIES
-.PHONY: open_prj open_gui start_hw_server open_hw_manager open_ila program_bitstream
+.PHONY: open_prj open_gui start_hw_server open_hw_manager open_ila program_bitstream program_bitstream_embedded program_bitstream_hpc

--- a/hw/xilinx/scripts/utils/pcie_hot_reset.sh
+++ b/hw/xilinx/scripts/utils/pcie_hot_reset.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script is inspired by corundum https://github.com/corundum/corundum/blob/master/fpga/lib/pcie/scripts/pcie_hot_reset.sh
+
+# TODO: find the dev automatically in the script
+dev=$1
+
+if [ -z "$dev" ]; then
+    echo "Error: no device specified"
+    exit 1
+fi
+
+if [ ! -e "/sys/bus/pci/devices/$dev" ]; then
+    dev="0000:$dev"
+fi
+
+if [ ! -e "/sys/bus/pci/devices/$dev" ]; then
+    echo "Error: device $dev not found"
+    exit 1
+fi
+
+port=$(basename $(dirname $(readlink "/sys/bus/pci/devices/$dev")))
+
+if [ ! -e "/sys/bus/pci/devices/$port" ]; then
+    echo "Error: device $port not found"
+    exit 1
+fi
+
+echo "Removing $dev..."
+
+echo 1 > "/sys/bus/pci/devices/$dev/remove"
+
+echo "Performing hot reset of port $port..."
+
+echo "Bridge control:" $(setpci -s $port BRIDGE_CONTROL)
+
+setpci -s $port BRIDGE_CONTROL=40:40
+sleep 0.5
+setpci -s $port BRIDGE_CONTROL=00:40
+sleep 0.5
+
+echo "Rescanning bus..."
+
+if [ -e "/sys/bus/pci/devices/$port/dev_rescan" ]; then
+    echo 1 > "/sys/bus/pci/devices/$port/dev_rescan"
+else
+    echo 1 > "/sys/bus/pci/devices/$port/rescan"
+fi
+
+


### PR DESCRIPTION
* [hw/xilinx] Add pcie_hot_reset.sh to hot reset the PCIe device and rescan.
* [hw/xilinx] Split the program_bitstream make target into program_bitstream_embedded and program_bitstream_hpc for calling the rescan. 

