### PR TITLE
[hw/xilinx] Add Vivado Linter run to bitstream build

### DIFF
--- a/hw/xilinx/synth/tcl/build_bitstream.tcl
+++ b/hw/xilinx/synth/tcl/build_bitstream.tcl
@@ -55,6 +55,35 @@ set project_dir [get_property directory [current_project]]
 set report_dir $project_dir/reports
 exec mkdir -p $report_dir
 
+##########
+# Linter #
+##########
+
+# Run linter
+set lint_filename $report_dir/lint.log
+synth_design -lint -file $lint_filename
+
+# Read-back file
+set fp [open $lint_filename r]
+set file_data [read $fp]
+close $fp
+# Parse for critical warnings
+set lines [split $file_data "\n"]
+set substring "CRITICAL WARNING"
+set line_cnt 0
+set critical_found "false"
+foreach line_value $lines {
+    set line_cnt [expr $line_cnt + 1]
+    if {[string first $substring $line_value] != -1} {
+        puts "\[ERROR\] Found $substring during linting! $lint_filename:$line_cnt"
+        set critical_found "true"
+    }
+}
+# Exit if found
+if { $critical_found == "true" } {
+    exit 1
+}
+
 ###################
 # RTL elaboration #
 ###################


### PR DESCRIPTION
- [x] Add a pre-synthesis and pre-elaboration scripted run to build_bitstream.tcl, dump to log file
- [x] Parse linter log file for `CRITICAL WARNING`s