### PR TITLE
[feature/cv64a6/atomics] Add support for AMO 

### DIFF
--- a/config/scripts/config_xilinx.sh
+++ b/config/scripts/config_xilinx.sh
@@ -176,7 +176,7 @@ for slave in ${slaves[*]}; do
         ddr_high=$(( ddr_base + (1 << range_width) - 1 ))
 
         # Path to the system cache TCL config
-        cache_config=${XILINX_IPS_ROOT}/common/xlnx_system_cache_0/config.tcl
+        cache_config=${XILINX_IPS_ROOT}/hpc/xlnx_system_cache_0/config.tcl
 
         # Update CACHE_BASEADDR in TCL
         sed -E -i "s#(set CACHE_BASEADDR)[[:space:]]*\{[^}]+\}#\1 {0x$(printf '%x' $ddr_base)}#g" "${cache_config}"

--- a/hw/units/custom_cv64a6/custom_top_wrapper.sv
+++ b/hw/units/custom_cv64a6/custom_top_wrapper.sv
@@ -1,4 +1,5 @@
 // Author: Stefano Mercogliano <stefano.mercogliano@unina.it>
+// Author: Valerio Di Domenico <valerio.didomenico@unina.it>
 // Description:
 //    This module is intended as a top-level wrapper for the custom_cv64a6
 //    unit used in the SoC rtl (in the Socket). It wraps the CV64A6 CPU from OpenHW.
@@ -6,6 +7,9 @@
 //    Cache sizes and microarchitectural features, such as RAS or BTB size.
 //    We use a slightly modified config file suited on our needs in ./assets.
 //    Extensions supported are: I M A F D C H
+//    The wrapper also instantiates the 'axi_riscv_atomics' module, which handles
+//    LR/SC and AMO instructions by translating them into standard AXI transactions,
+//    ensuring proper atomic operation support on AXI-based memory systems.
 
 
 // Import headers
@@ -37,7 +41,8 @@ module custom_top_wrapper # (
     parameter LOCAL_AXI_READY_WIDTH   = 1,
     parameter LOCAL_AXI_LAST_WIDTH    = 1,
     parameter LOCAL_AXI_RESP_WIDTH    = 2,
-    parameter LOCAL_AXI_USER_WIDTH    = 64
+    parameter LOCAL_AXI_USER_WIDTH    = 64,
+    parameter USE_ATOMICS             = 0
 
 ) (
 
@@ -107,47 +112,155 @@ module custom_top_wrapper # (
     .noc_req_o      ( axi_req     ),
     .noc_resp_i     ( axi_rsp     )
   );
+generate
+  if(USE_ATOMICS) begin : gen_with_atomics
+    axi_riscv_atomics #(
+            .AXI_ADDR_WIDTH     (LOCAL_AXI_ADDR_WIDTH),
+            .AXI_DATA_WIDTH     (LOCAL_AXI_DATA_WIDTH),
+            .AXI_ID_WIDTH       (LOCAL_AXI_ID_WIDTH),
+            .AXI_USER_WIDTH     (LOCAL_AXI_USER_WIDTH),
+            .AXI_MAX_WRITE_TXNS (1),
+            .RISCV_WORD_WIDTH   (64)
+        ) i_atomics (
+            .clk_i           ( clk_i         ),
+            .rst_ni          ( rst_ni        ),
+            .slv_aw_addr_i   ( axi_req.aw.addr   ),
+            .slv_aw_prot_i   ( axi_req.aw.prot   ),
+            .slv_aw_region_i ( axi_req.aw.region ),
+            .slv_aw_atop_i   ( axi_req.aw.atop   ),
+            .slv_aw_len_i    ( axi_req.aw.len    ),
+            .slv_aw_size_i   ( axi_req.aw.size   ),
+            .slv_aw_burst_i  ( axi_req.aw.burst  ),
+            .slv_aw_lock_i   ( axi_req.aw.lock   ),
+            .slv_aw_cache_i  ( axi_req.aw.cache  ),
+            .slv_aw_qos_i    ( axi_req.aw.qos    ),
+            .slv_aw_id_i     ( axi_req.aw.id     ),
+            .slv_aw_user_i   ( axi_req.aw.user   ),
+            .slv_aw_ready_o  ( axi_rsp.aw_ready  ),
+            .slv_aw_valid_i  ( axi_req.aw_valid  ),
+            .slv_ar_addr_i   ( axi_req.ar.addr   ),
+            .slv_ar_prot_i   ( axi_req.ar.prot   ),
+            .slv_ar_region_i ( axi_req.ar.region ),
+            .slv_ar_len_i    ( axi_req.ar.len    ),
+            .slv_ar_size_i   ( axi_req.ar.size   ),
+            .slv_ar_burst_i  ( axi_req.ar.burst  ),
+            .slv_ar_lock_i   ( axi_req.ar.lock   ),
+            .slv_ar_cache_i  ( axi_req.ar.cache  ),
+            .slv_ar_qos_i    ( axi_req.ar.qos    ),
+            .slv_ar_id_i     ( axi_req.ar.id     ),
+            .slv_ar_user_i   ( axi_req.ar.user   ),
+            .slv_ar_ready_o  ( axi_rsp.ar_ready  ),
+            .slv_ar_valid_i  ( axi_req.ar_valid  ),
+            .slv_w_data_i    ( axi_req.w.data    ),
+            .slv_w_strb_i    ( axi_req.w.strb    ),
+            .slv_w_user_i    ( axi_req.w.user    ),
+            .slv_w_last_i    ( axi_req.w.last    ),
+            .slv_w_ready_o   ( axi_rsp.w_ready   ),
+            .slv_w_valid_i   ( axi_req.w_valid   ),
+            .slv_r_data_o    ( axi_rsp.r.data    ),
+            .slv_r_resp_o    ( axi_rsp.r.resp    ),
+            .slv_r_last_o    ( axi_rsp.r.last    ),
+            .slv_r_id_o      ( axi_rsp.r.id      ),
+            .slv_r_user_o    ( axi_rsp.r.user    ),
+            .slv_r_ready_i   ( axi_req.r_ready  ),
+            .slv_r_valid_o   ( axi_rsp.r_valid   ),
+            .slv_b_resp_o    ( axi_rsp.b.resp    ),
+            .slv_b_id_o      ( axi_rsp.b.id      ),
+            .slv_b_user_o    ( axi_rsp.b.user    ),
+            .slv_b_ready_i   ( axi_req.b_ready   ),
+            .slv_b_valid_o   ( axi_rsp.b_valid   ),
+            .mst_aw_addr_o   ( m_axi_awaddr   ),
+            .mst_aw_prot_o   ( m_axi_awprot   ),
+            .mst_aw_region_o ( m_axi_awregion ),
+            .mst_aw_atop_o   ( m_axi_awatop   ),
+            .mst_aw_len_o    ( m_axi_awlen    ),
+            .mst_aw_size_o   ( m_axi_awsize   ),
+            .mst_aw_burst_o  ( m_axi_awburst  ),
+            .mst_aw_lock_o   ( m_axi_awlock   ),
+            .mst_aw_cache_o  ( m_axi_awcache  ),
+            .mst_aw_qos_o    ( m_axi_awqos    ),
+            .mst_aw_id_o     ( m_axi_awid     ),
+            .mst_aw_user_o   ( m_axi_awuser   ),
+            .mst_aw_ready_i  ( m_axi_awready  ),
+            .mst_aw_valid_o  ( m_axi_awvalid  ),
+            .mst_ar_addr_o   ( m_axi_araddr   ),
+            .mst_ar_prot_o   ( m_axi_arprot   ),
+            .mst_ar_region_o ( m_axi_arregion ),
+            .mst_ar_len_o    ( m_axi_arlen    ),
+            .mst_ar_size_o   ( m_axi_arsize   ),
+            .mst_ar_burst_o  ( m_axi_arburst  ),
+            .mst_ar_lock_o   ( m_axi_arlock   ),
+            .mst_ar_cache_o  ( m_axi_arcache  ),
+            .mst_ar_qos_o    ( m_axi_arqos    ),
+            .mst_ar_id_o     ( m_axi_arid     ),
+            .mst_ar_user_o   ( m_axi_aruser   ),
+            .mst_ar_ready_i  ( m_axi_arready  ),
+            .mst_ar_valid_o  ( m_axi_arvalid  ),
+            .mst_w_data_o    ( m_axi_wdata    ),
+            .mst_w_strb_o    ( m_axi_wstrb    ),
+            .mst_w_user_o    ( m_axi_wuser    ),
+            .mst_w_last_o    ( m_axi_wlast    ),
+            .mst_w_ready_i   ( m_axi_wready   ),
+            .mst_w_valid_o   ( m_axi_wvalid   ),
+            .mst_r_data_i    ( m_axi_rdata    ),
+            .mst_r_resp_i    ( m_axi_rresp    ),
+            .mst_r_last_i    ( m_axi_rlast    ),
+            .mst_r_id_i      ( m_axi_rid      ),
+            .mst_r_user_i    ( m_axi_ruser    ),
+            .mst_r_ready_o   ( m_axi_rready   ),
+            .mst_r_valid_i   ( m_axi_rvalid   ),
+            .mst_b_resp_i    ( m_axi_bresp    ),
+            .mst_b_id_i      ( m_axi_bid      ),
+            .mst_b_user_i    ( m_axi_buser    ),
+            .mst_b_ready_o   ( m_axi_bready   ),
+            .mst_b_valid_i   ( m_axi_bvalid   )
+        );
 
-  // Map master port signals
-  assign m_axi_awid      = axi_req.aw.id;
-  assign m_axi_awaddr    = axi_req.aw.addr;
-  assign m_axi_awlen     = axi_req.aw.len;
-  assign m_axi_awsize    = axi_req.aw.size;
-  assign m_axi_awburst   = axi_req.aw.burst;
-  assign m_axi_awlock    = axi_req.aw.lock;
-  assign m_axi_awcache   = axi_req.aw.cache;
-  assign m_axi_awprot    = axi_req.aw.prot;
-  assign m_axi_awqos     = axi_req.aw.qos;
-  assign m_axi_awregion  = axi_req.aw.region;
-  assign m_axi_awvalid   = axi_req.aw_valid;
-  assign m_axi_wdata     = axi_req.w.data;
-  assign m_axi_wstrb     = axi_req.w.strb;
-  assign m_axi_wlast     = axi_req.w.last;
-  assign m_axi_wvalid    = axi_req.w_valid;
-  assign m_axi_bready    = axi_req.b_ready;
-  assign m_axi_araddr    = axi_req.ar.addr;
-  assign m_axi_arlen     = axi_req.ar.len;
-  assign m_axi_arsize    = axi_req.ar.size;
-  assign m_axi_arburst   = axi_req.ar.burst;
-  assign m_axi_arlock    = axi_req.ar.lock;
-  assign m_axi_arcache   = axi_req.ar.cache;
-  assign m_axi_arprot    = axi_req.ar.prot;
-  assign m_axi_arqos     = axi_req.ar.qos;
-  assign m_axi_arregion  = axi_req.ar.region;
-  assign m_axi_arvalid   = axi_req.ar_valid;
-  assign m_axi_rready    = axi_req.r_ready;
-  assign m_axi_arid      = axi_req.ar.id;
+  end else begin : gen_direct_axi_map
 
-  assign axi_rsp.aw_ready = m_axi_awready;
-  assign axi_rsp.w_ready  = m_axi_wready;
-  assign axi_rsp.b.id     = m_axi_bid;
-  assign axi_rsp.b.resp   = m_axi_bresp;
-  assign axi_rsp.b_valid  = m_axi_bvalid;
-  assign axi_rsp.ar_ready = m_axi_arready;
-  assign axi_rsp.r.id     = m_axi_rid;
-  assign axi_rsp.r.data   = m_axi_rdata;
-  assign axi_rsp.r.resp   = m_axi_rresp;
-  assign axi_rsp.r.last   = m_axi_rlast;
-  assign axi_rsp.r_valid  = m_axi_rvalid;
+    // Map master port signals
+    assign m_axi_awid      = axi_req.aw.id;
+    assign m_axi_awaddr    = axi_req.aw.addr;
+    assign m_axi_awlen     = axi_req.aw.len;
+    assign m_axi_awsize    = axi_req.aw.size;
+    assign m_axi_awburst   = axi_req.aw.burst;
+    assign m_axi_awlock    = axi_req.aw.lock;
+    assign m_axi_awcache   = axi_req.aw.cache;
+    assign m_axi_awprot    = axi_req.aw.prot;
+    assign m_axi_awqos     = axi_req.aw.qos;
+    assign m_axi_awregion  = axi_req.aw.region;
+    assign m_axi_awvalid   = axi_req.aw_valid;
+    assign m_axi_wdata     = axi_req.w.data;
+    assign m_axi_wstrb     = axi_req.w.strb;
+    assign m_axi_wlast     = axi_req.w.last;
+    assign m_axi_wvalid    = axi_req.w_valid;
+    assign m_axi_bready    = axi_req.b_ready;
+    assign m_axi_araddr    = axi_req.ar.addr;
+    assign m_axi_arlen     = axi_req.ar.len;
+    assign m_axi_arsize    = axi_req.ar.size;
+    assign m_axi_arburst   = axi_req.ar.burst;
+    assign m_axi_arlock    = axi_req.ar.lock;
+    assign m_axi_arcache   = axi_req.ar.cache;
+    assign m_axi_arprot    = axi_req.ar.prot;
+    assign m_axi_arqos     = axi_req.ar.qos;
+    assign m_axi_arregion  = axi_req.ar.region;
+    assign m_axi_arvalid   = axi_req.ar_valid;
+    assign m_axi_rready    = axi_req.r_ready;
+    assign m_axi_arid      = axi_req.ar.id;
+
+    assign axi_rsp.aw_ready = m_axi_awready;
+    assign axi_rsp.w_ready  = m_axi_wready;
+    assign axi_rsp.b.id     = m_axi_bid;
+    assign axi_rsp.b.resp   = m_axi_bresp;
+    assign axi_rsp.b_valid  = m_axi_bvalid;
+    assign axi_rsp.ar_ready = m_axi_arready;
+    assign axi_rsp.r.id     = m_axi_rid;
+    assign axi_rsp.r.data   = m_axi_rdata;
+    assign axi_rsp.r.resp   = m_axi_rresp;
+    assign axi_rsp.r.last   = m_axi_rlast;
+    assign axi_rsp.r_valid  = m_axi_rvalid;
+
+  end
+endgenerate
 
 endmodule : custom_top_wrapper

--- a/sw/SoC/examples/Zaamo_test/Makefile
+++ b/sw/SoC/examples/Zaamo_test/Makefile
@@ -1,0 +1,55 @@
+# Author: Stefano Mercogliano <stefano.mercogliano@unina.it>
+# Author: Salvatore Santoro <sal.santoro@studenti.unina.it>
+# Description:
+#   This Makefile defines the project name and paths for the common Makefile.
+#   Optionally, a user can define additional targets here.
+
+################
+# Program Name #
+################
+
+# Get program name from directory name
+PROGRAM_NAME = $(shell basename $$PWD)
+
+#############
+# Toolchain #
+#############
+
+#####################
+# Paths and Folders #
+#####################
+
+SOC_SW_ROOT_DIR = $(SW_ROOT)/SoC
+
+SRC_DIR        = src
+OBJ_DIR        = obj
+INC_DIR     = inc
+STARTUP_DIR = $(SOC_SW_ROOT_DIR)/common
+
+LD_SCRIPT     = ld/user.ld
+
+#############
+# Libraries #
+#############
+
+LIB_OBJ_TINYIO    = $(LIB_DIR)/tinyio/lib/tinyio.a
+LIB_INC_TINYIO    = -I$(LIB_DIR)/tinyio/inc
+
+LIB_OBJ_UNINASOC  = $(LIB_DIR)/uninasoc/lib/libuninasoc.a
+LIB_INC_UNINASOC   = -I$(LIB_DIR)/uninasoc/inc
+
+LIB_OBJ_LIST     = $(LIB_OBJ_TINYIO) $(LIB_OBJ_UNINASOC)
+LIB_INC_LIST     = $(LIB_INC_TINYIO) $(LIB_INC_UNINASOC)
+
+
+#############
+# Toolchain #
+#############
+
+include $(SW_ROOT)/SoC/common/config.mk
+
+###########
+# Targets #
+###########
+
+include $(SW_ROOT)/SoC/common/Makefile

--- a/sw/SoC/examples/Zaamo_test/ld/user.ld
+++ b/sw/SoC/examples/Zaamo_test/ld/user.ld
@@ -1,0 +1,10 @@
+/*
+    *** User-defined linker script ***
+    Extends UninaSoC.ld by defining DDR start/end symbols
+*/
+
+INCLUDE ../../common/UninaSoC.ld
+
+/* Define DDR start/end symbols globally */
+PROVIDE(_DDR_start = ORIGIN(DDR));
+PROVIDE(_DDR_end   = ORIGIN(DDR) + LENGTH(DDR));

--- a/sw/SoC/examples/Zaamo_test/src/main.c
+++ b/sw/SoC/examples/Zaamo_test/src/main.c
@@ -1,0 +1,283 @@
+/*
+ *  Author: Valerio Di Domenico <valerio.didomenico@unina.it>
+ *
+ * ==============================================================
+ *  RISC-V Atomic Memory Operations (AMO) Functional Test
+ * ==============================================================
+
+ *  Description:
+ *  This program tests the behavior of all standard RISC-V AMO
+ *  (Atomic Memory Operation) instructions, verifying that each
+ *  operation updates the target memory location correctly.
+ *
+ *  The tests are divided into two parts:
+ *   - Word-level tests (32-bit): always compiled
+ *   - Doubleword-level tests (64-bit): compiled only when
+ *     building for RV64 targets
+ *
+ *  Tested instructions:
+ *    1. amoswap.w / amoswap.d
+ *    2. amoadd.w  / amoadd.d
+ *    3. amoand.w  / amoand.d
+ *    4. amoor.w   / amoor.d
+ *    5. amoxor.w  / amoxor.d
+ *    6. amomax.w  / amomax.d
+ *    7. amomaxu.w / amomaxu.d
+ *    8. amomin.w  / amomin.d
+ *    9. amominu.w / amominu.d
+ *
+ *  Each test:
+ *    - Initializes a memory location in DDR
+ *    - Executes the AMO instruction using inline assembly
+ *    - Compares the result in memory with the expected value
+ *    - Prints “SUCCESS” or “FAILED” for each operation
+ *
+ * ==============================================================
+ */
+
+#include "uninasoc.h"
+#include <stdint.h>
+
+extern unsigned int _DDR_start;
+extern unsigned int _DDR_end;
+
+int main(int argc, char* argv[]) {
+
+    // Initialize HAL
+    uninasoc_init();
+
+    uintptr_t ddr_base = (uintptr_t)&_DDR_start;
+    uintptr_t ddr_end  = (uintptr_t)&_DDR_end;
+
+    printf("=== RISC-V AMO FUNCTIONAL TEST START ===\n\r");
+
+    // ==========================================================
+    //                    WORD (32-bit) TESTS
+    // ==========================================================
+    volatile int *a_ptr_w = (int *)ddr_base;
+    int old_val_w;
+
+    *a_ptr_w = 0x10;
+
+    // ---------- 1. AMOSWAP.W ----------
+    int swap_val_w = 0x33;
+    __asm__ volatile ("amoswap.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(swap_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if (*a_ptr_w == swap_val_w)
+        printf("AMOSWAP.W SUCCESS\n\r");
+    else
+        printf("AMOSWAP.W FAILED\n\r");
+
+    // ---------- 2. AMOADD.W ----------
+    int add_val_w = 0x5;
+    __asm__ volatile ("amoadd.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(add_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if (*a_ptr_w == old_val_w + add_val_w)
+        printf("AMOADD.W SUCCESS\n\r");
+    else
+        printf("AMOADD.W FAILED\n\r");
+
+    // ---------- 3. AMOAND.W ----------
+    int and_val_w = 0xF;
+    __asm__ volatile ("amoand.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(and_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if (*a_ptr_w == (old_val_w & and_val_w))
+        printf("AMOAND.W SUCCESS\n\r");
+    else
+        printf("AMOAND.W FAILED\n\r");
+
+    // ---------- 4. AMOOR.W ----------
+    int or_val_w = 0x80;
+    __asm__ volatile ("amoor.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(or_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if (*a_ptr_w == (old_val_w | or_val_w))
+        printf("AMOOR.W SUCCESS\n\r");
+    else
+        printf("AMOOR.W FAILED\n\r");
+
+    // ---------- 5. AMOXOR.W ----------
+    int xor_val_w = 0xA;
+    __asm__ volatile ("amoxor.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(xor_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if (*a_ptr_w == (old_val_w ^ xor_val_w))
+        printf("AMOXOR.W SUCCESS\n\r");
+    else
+        printf("AMOXOR.W FAILED\n\r");
+
+    // ---------- 6. AMOMAX.W ----------
+    *a_ptr_w = 0x5;
+    int max_val_w = -3;
+    __asm__ volatile ("amomax.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(max_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if (*a_ptr_w == ((old_val_w > max_val_w) ? old_val_w : max_val_w))
+        printf("AMOMAX.W SUCCESS\n\r");
+    else
+        printf("AMOMAX.W FAILED\n\r");
+
+    // ---------- 7. AMOMAXU.W ----------
+    unsigned int maxu_val_w = 0xFFFFFFF0;
+    __asm__ volatile ("amomaxu.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(maxu_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if ((unsigned int)*a_ptr_w == ((unsigned int)old_val_w > maxu_val_w ?
+                                   (unsigned int)old_val_w : maxu_val_w))
+        printf("AMOMAXU.W SUCCESS\n\r");
+    else
+        printf("AMOMAXU.W FAILED\n\r");
+
+    // ---------- 8. AMOMIN.W ----------
+    *a_ptr_w = 0x5;
+    int min_val_w = -3;
+    __asm__ volatile ("amomin.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(min_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if (*a_ptr_w == ((old_val_w < min_val_w) ? old_val_w : min_val_w))
+        printf("AMOMIN.W SUCCESS\n\r");
+    else
+        printf("AMOMIN.W FAILED\n\r");
+
+    // ---------- 9. AMOMINU.W ----------
+    unsigned int minu_val_w = 0xFFFFFFF0;
+    __asm__ volatile ("amominu.w %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_w)
+                      : [val] "r"(minu_val_w), [addr] "r"(a_ptr_w)
+                      : "memory");
+    if ((unsigned int)*a_ptr_w == ((unsigned int)old_val_w < minu_val_w ?
+                                   (unsigned int)old_val_w : minu_val_w))
+        printf("AMOMINU.W SUCCESS\n\r");
+    else
+        printf("AMOMINU.W FAILED\n\r");
+
+
+    // ==========================================================
+    //                 DOUBLEWORD (64-bit) TESTS
+    // ==========================================================
+#ifdef __LP64__
+    volatile long *a_ptr_d = (long *)(ddr_base + 0x100);
+    long old_val_d;
+
+    *a_ptr_d = 0x10;
+
+    // ---------- 1. AMOSWAP.D ----------
+    long swap_val_d = 0x12345678ABCDEF00;
+    __asm__ volatile ("amoswap.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(swap_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if (*a_ptr_d == swap_val_d)
+        printf("AMOSWAP.D SUCCESS\n\r");
+    else
+        printf("AMOSWAP.D FAILED\n\r");
+
+    // ---------- 2. AMOADD.D ----------
+    long add_val_d = 0x10;
+    __asm__ volatile ("amoadd.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(add_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if (*a_ptr_d == old_val_d + add_val_d)
+        printf("AMOADD.D SUCCESS\n\r");
+    else
+        printf("AMOADD.D FAILED\n\r");
+
+    // ---------- 3. AMOAND.D ----------
+    long and_val_d = 0xFFFFFFFFFFFFFF0F;
+    __asm__ volatile ("amoand.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(and_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if (*a_ptr_d == (old_val_d & and_val_d))
+        printf("AMOAND.D SUCCESS\n\r");
+    else
+        printf("AMOAND.D FAILED\n\r");
+
+    // ---------- 4. AMOOR.D ----------
+    long or_val_d = 0x100;
+    __asm__ volatile ("amoor.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(or_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if (*a_ptr_d == (old_val_d | or_val_d))
+        printf("AMOOR.D SUCCESS\n\r");
+    else
+        printf("AMOOR.D FAILED\n\r");
+
+    // ---------- 5. AMOXOR.D ----------
+    long xor_val_d = 0x55AA;
+    __asm__ volatile ("amoxor.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(xor_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if (*a_ptr_d == (old_val_d ^ xor_val_d))
+        printf("AMOXOR.D SUCCESS\n\r");
+    else
+        printf("AMOXOR.D FAILED\n\r");
+
+    // ---------- 6. AMOMAX.D ----------
+    *a_ptr_d = 0x5;
+    long max_val_d = -3;
+    __asm__ volatile ("amomax.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(max_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if (*a_ptr_d == ((old_val_d > max_val_d) ? old_val_d : max_val_d))
+        printf("AMOMAX.D SUCCESS\n\r");
+    else
+        printf("AMOMAX.D FAILED\n\r");
+
+    // ---------- 7. AMOMAXU.D ----------
+    unsigned long maxu_val_d = 0xFFFFFFFFFFFFFF00;
+    __asm__ volatile ("amomaxu.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(maxu_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if ((unsigned long)*a_ptr_d == ((unsigned long)old_val_d > maxu_val_d ?
+                                    (unsigned long)old_val_d : maxu_val_d))
+        printf("AMOMAXU.D SUCCESS\n\r");
+    else
+        printf("AMOMAXU.D FAILED\n\r");
+
+    // ---------- 8. AMOMIN.D ----------
+    *a_ptr_d = 0x5;
+    long min_val_d = -3;
+    __asm__ volatile ("amomin.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(min_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if (*a_ptr_d == ((old_val_d < min_val_d) ? old_val_d : min_val_d))
+        printf("AMOMIN.D SUCCESS\n\r");
+    else
+        printf("AMOMIN.D FAILED\n\r");
+
+    // ---------- 9. AMOMINU.D ----------
+    unsigned long minu_val_d = 0xFFFFFFFFFFFFFF00;
+    __asm__ volatile ("amominu.d %[old], %[val], (%[addr])"
+                      : [old] "=r"(old_val_d)
+                      : [val] "r"(minu_val_d), [addr] "r"(a_ptr_d)
+                      : "memory");
+    if ((unsigned long)*a_ptr_d == ((unsigned long)old_val_d < minu_val_d ?
+                                    (unsigned long)old_val_d : minu_val_d))
+        printf("AMOMINU.D SUCCESS\n\r");
+    else
+        printf("AMOMINU.D FAILED\n\r");
+#endif
+
+    printf("=== RISC-V AMO FUNCTIONAL TEST END ===\n\r");
+
+    while (1) {};
+    return 0;
+}


### PR DESCRIPTION
This PR introduces support for RISC-V atomic memory operations (AMOs) in the CVA6 core.
- [hw/units/cv64a6] Add optional PULP AMO adapter https://github.com/pulp-platform/axi_riscv_atomics/tree/v0.2.2 to cv64a6's custom_top_wrapper
- [hw/units/cv64a6] Add configuration parameter USE_ATOMICS in cv64a6's custom_top_wrapper to enable AMO support module.
- [sw/SoC] Add test for instructions (AMOADD, AMOXOR, AMOAND, AMOOR, AMOMIN, AMOMAX, AMOMINU, AMOMAXU, AMOSWAP)

TODO: test plan